### PR TITLE
Drop support for dbt versions below 1.3 (Close #19)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,8 @@
 name: 'snowplow_media_player'
 version: '0.3.3'
 config-version: 2
-require-dbt-version: ">=1.0.0"
+
+require-dbt-version: [">=1.3.0", "<2.0.0"]
 
 profile: 'default'
 
@@ -19,6 +20,8 @@ clean-targets:
   - "dbt_packages"
 
 vars:
+  surrogate_key_treat_nulls_as_empty_strings: true # turn on legacy behavior
+
   snowplow__percent_progress_boundaries: [10, 25, 50, 75]
   snowplow__valid_play_sec: 30
   snowplow__complete_play_rate: 0.99

--- a/models/custom/snowplow_media_player_session_stats.sql
+++ b/models/custom/snowplow_media_player_session_stats.sql
@@ -27,9 +27,9 @@ with prep as (
     min(start_tstamp) start_tstamp,
     max(end_tstamp) as end_tstamp,
     sum(seeks) as seeks,
-    sum(play_time_sec / cast(60 as {{ dbt_utils.type_float() }})) as play_time_min,
-    sum(play_time_sec_muted / cast(60 as {{ dbt_utils.type_float() }})) as play_time_min_muted,
-    coalesce(avg(case when is_played then play_time_sec / cast(60 as {{ dbt_utils.type_float() }}) end), 0) as avg_play_time_min,
+    sum(play_time_sec / cast(60 as {{ type_float() }})) as play_time_min,
+    sum(play_time_sec_muted / cast(60 as {{ type_float() }})) as play_time_min_muted,
+    coalesce(avg(case when is_played then play_time_sec / cast(60 as {{ type_float() }}) end), 0) as avg_play_time_min,
     coalesce(avg(case when is_played then coalesce(play_time_sec / nullif(duration, 0), 0) end),0) as avg_percent_played,
     sum(case when is_complete_play then 1 else 0 end) as complete_plays
 

--- a/models/custom/snowplow_media_player_user_stats.sql
+++ b/models/custom/snowplow_media_player_user_stats.sql
@@ -24,9 +24,9 @@ with prep as (
     sum(valid_audio_plays) as valid_audio_plays,
     sum(complete_plays) as complete_plays,
     sum(seeks) as seeks,
-    cast(sum(play_time_min) as {{ dbt_utils.type_int() }}) as play_time_min,
+    cast(sum(play_time_min) as {{ type_int() }}) as play_time_min,
     -- using session and not page_view as the base for average to save cost by not joining on snowplow_media_player_base for calculating on individual page_view level average
-    coalesce(cast(avg(case when (video_plays + audio_plays) > 0 then avg_play_time_min end) as {{ dbt_utils.type_int() }}), 0) as avg_session_play_time_min,
+    coalesce(cast(avg(case when (video_plays + audio_plays) > 0 then avg_play_time_min end) as {{ type_int() }}), 0) as avg_session_play_time_min,
     coalesce(avg(avg_percent_played),0) as avg_percent_played
 
   from {{ ref("snowplow_media_player_session_stats") }}

--- a/models/web/scratch/interactions_this_run/bigquery/snowplow_media_player_interactions_this_run.sql
+++ b/models/web/scratch/interactions_this_run/bigquery/snowplow_media_player_interactions_this_run.sql
@@ -257,10 +257,10 @@ with prep as (
 )
 
  select
-  {{ dbt_utils.surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
+  {{ dbt_utils.generate_surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
   p.*,
-  coalesce(cast(piv.weight_rate * p.duration / 100 as {{ dbt_utils.type_int() }}), 0) as play_time_sec,
-  coalesce(cast(case when p.is_muted = true then piv.weight_rate * p.duration / 100 else 0 end as {{ dbt_utils.type_int() }}), 0) as play_time_sec_muted
+  coalesce(cast(piv.weight_rate * p.duration / 100 as {{ type_int() }}), 0) as play_time_sec,
+  coalesce(cast(case when p.is_muted = true then piv.weight_rate * p.duration / 100 else 0 end as {{ type_int() }}), 0) as play_time_sec_muted
 
   from prep p
 

--- a/models/web/scratch/interactions_this_run/databricks/snowplow_media_player_interactions_this_run.sql
+++ b/models/web/scratch/interactions_this_run/databricks/snowplow_media_player_interactions_this_run.sql
@@ -72,10 +72,10 @@ with prep as (
 )
 
  select
-  {{ dbt_utils.surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
+  {{ dbt_utils.generate_surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
   p.*,
-  coalesce(cast(round(piv.weight_rate * p.duration / 100) as {{ dbt_utils.type_int() }}), 0) as play_time_sec,
-  coalesce(cast(case when p.is_muted = true then round(piv.weight_rate * p.duration / 100) else 0 end as {{ dbt_utils.type_int() }}), 0) as play_time_sec_muted
+  coalesce(cast(round(piv.weight_rate * p.duration / 100) as {{ type_int() }}), 0) as play_time_sec,
+  coalesce(cast(case when p.is_muted = true then round(piv.weight_rate * p.duration / 100) else 0 end as {{ type_int() }}), 0) as play_time_sec_muted
 
   from prep p
 

--- a/models/web/scratch/interactions_this_run/redshift_postgres/snowplow_media_player_interactions_this_run.sql
+++ b/models/web/scratch/interactions_this_run/redshift_postgres/snowplow_media_player_interactions_this_run.sql
@@ -92,10 +92,10 @@ with prep as (
 )
 
  select
- {{ dbt_utils.surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
+ {{ dbt_utils.generate_surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
   p.*,
-  coalesce(cast(round(piv.weight_rate * p.duration / 100) as {{ dbt_utils.type_int() }}), 0) as play_time_sec,
-  coalesce(cast(case when p.is_muted then round(piv.weight_rate * p.duration / 100) end as {{ dbt_utils.type_int() }}), 0) as play_time_sec_muted
+  coalesce(cast(round(piv.weight_rate * p.duration / 100) as {{ type_int() }}), 0) as play_time_sec,
+  coalesce(cast(case when p.is_muted then round(piv.weight_rate * p.duration / 100) end as {{ type_int() }}), 0) as play_time_sec_muted
 
   from prep p
 

--- a/models/web/scratch/interactions_this_run/snowflake/snowplow_media_player_interactions_this_run.sql
+++ b/models/web/scratch/interactions_this_run/snowflake/snowplow_media_player_interactions_this_run.sql
@@ -74,10 +74,10 @@ with prep as (
 )
 
  select
-  {{ dbt_utils.surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
+  {{ dbt_utils.generate_surrogate_key(['p.page_view_id', 'p.media_id' ]) }} play_id,
   p.*,
-  coalesce(cast(piv.weight_rate * p.duration / 100 as {{ dbt_utils.type_int() }}), 0) as play_time_sec,
-  coalesce(cast(case when p.is_muted = true then piv.weight_rate * p.duration / 100 else 0 end as {{ dbt_utils.type_int() }}), 0) as play_time_sec_muted
+  coalesce(cast(piv.weight_rate * p.duration / 100 as {{ type_int() }}), 0) as play_time_sec,
+  coalesce(cast(case when p.is_muted = true then piv.weight_rate * p.duration / 100 else 0 end as {{ type_int() }}), 0) as play_time_sec_muted
 
   from prep p
 

--- a/models/web/scratch/snowplow_media_player_base_this_run.sql
+++ b/models/web/scratch/snowplow_media_player_base_this_run.sql
@@ -115,11 +115,11 @@ select
   d.plays > 0 as is_played,
   case when d.play_time_sec > {{ var("snowplow__valid_play_sec") }} then true else false end is_valid_play,
   case when play_time_sec / nullif(f.duration, 0) >= {{ var("snowplow__complete_play_rate") }} then true else false end as is_complete_play,
-  cast(d.avg_playback_rate as {{ dbt_utils.type_float() }}) as avg_playback_rate,
+  cast(d.avg_playback_rate as {{ type_float() }}) as avg_playback_rate,
   cast(coalesce(case when r.retention_rate > d.max_percent_progress
-          then d.max_percent_progress / cast(100 as {{ dbt_utils.type_float() }})
-          else r.retention_rate / cast(100 as {{ dbt_utils.type_float() }})
-          end, 0) as {{ dbt_utils.type_float() }}) as retention_rate, -- to correct incorrect result due to duplicate session_id (one removed)
+          then d.max_percent_progress / cast(100 as {{ type_float() }})
+          else r.retention_rate / cast(100 as {{ type_float() }})
+          end, 0) as {{ type_float() }}) as retention_rate, -- to correct incorrect result due to duplicate session_id (one removed)
   d.seeks,
   case when d.percent_progress_reached = '' then null else d.percent_progress_reached end as percent_progress_reached
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
-  - package: snowplow/snowplow_web
-    version: [">=0.12.0", "<0.13.0"]
+  # - package: snowplow/snowplow_web
+  #   version: [">=0.12.0", "<0.13.0"]
+  - git: "https://github.com/snowplow/dbt-snowplow-web.git"
+    revision: feature/remove-deprecated-macros

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_web
-    version: [">=0.10.0", "<0.11.0"]
+    version: [">=0.12.0", "<0.13.0"]


### PR DESCRIPTION
## Description & motivation
Update dbt-snowplow-media-player to support dbt v1.3+ and `dbt-utils` v1.0.0

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
