### PR TITLE
Release/snowplow media player/0.5.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-media-player 0.5.3 (2023-09-04)
+---------------------------------------
+## Summary
+This release fixes a problem reported with the media_stats model failing during incremental runs when the table is empty.
+
+## Fixes
+Fix errors during media_stats incremental runs in case the table is empty (close #51)
+
+## Upgrading
+To upgrade simply bump the snowplow-web and snowplow-media-player version in your `packages.yml` file.
+
 snowplow-media-player 0.5.2 (2023-08-16)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_media_player'
-version: '0.5.2'
+version: '0.5.3'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_media_player_integration_tests'
-version: '0.5.2'
+version: '0.5.3'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/web/snowplow_media_player_media_stats.sql
+++ b/models/web/snowplow_media_player_media_stats.sql
@@ -45,7 +45,10 @@ from {{ ref("snowplow_media_player_base") }} p
 where -- enough time has passed since the page_view's start_tstamp to be able to process it as a whole (please bear in mind the late arriving data)
 cast({{ dateadd('hour', var("snowplow__max_media_pv_window", 10), 'p.end_tstamp ') }} as {{ type_timestamp() }}) < {{ snowplow_utils.current_timestamp_in_utc() }}
 -- and it has not been processed yet
-and p.start_tstamp > ( select max(last_base_tstamp) from {{ this }} )
+and (
+  not exists(select 1 from {{ this }}) or -- no records in the table
+  p.start_tstamp > ( select max(last_base_tstamp) from {{ this }} )
+)
 
 group by 1,2,4,5
 


### PR DESCRIPTION
## Description & motivation
This release fixes a problem reported with the media_stats model failing during incremental runs when the table is empty.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 
