### PR TITLE
Make play_time_secs reference configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-media-player 0.9.4 (2025-10-09)
+---------------------------------------
+## Summary
+There has been a request from users to be able to decide how to calculate the `play_time_secs` within the base_this_run table to handle edge cases in tracking. This is enabled via a new dispatch macro called `play_time_secs_base_this_run()` where users will be free to override the reference.
+
+## Features
+- Make play_time_secs reference configurable
+
+## Upgrading  
+Update the snowplow-media-player version in your packages.yml file.
+
 snowplow-media-player 0.9.3 (2025-07-28)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_media_player'
-version: '0.9.3'
+version: '0.9.4'
 config-version: 2
 
 require-dbt-version: ['>=1.4.0', '<2.0.0']

--- a/docs/markdown/snowplow_media_player_macro_docs.md
+++ b/docs/markdown/snowplow_media_player_macro_docs.md
@@ -196,3 +196,11 @@ A macro that checks if at least one of the platform enabling variables is true a
 
 {% endraw %}
 {% enddocs %}
+
+{% docs macro_play_time_secs_base_this_run %}
+{% raw %}
+
+A macro for users to optionally configure how the play_time_secs is calculated in the snowplow_media_player_base_this_run table. E.g. to avoid edge cases depending on tracking behaviour.
+
+{% endraw %}
+{% enddocs %}

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_media_player_integration_tests'
-version: '0.9.3'
+version: '0.9.4'
 config-version: 2
 
 profile: 'integration_tests'

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -96,3 +96,6 @@ macros:
 
   - name: config_check
     description: '{{ doc("macro_config_check") }}'
+    
+  - name: play_time_secs_base_this_run
+    description: '{{ doc("macro_play_time_secs_base_this_run") }}'

--- a/macros/play_time_secs_base_this_run.sql
+++ b/macros/play_time_secs_base_this_run.sql
@@ -1,0 +1,10 @@
+
+{% macro play_time_secs_base_this_run() %}
+  {{ return(adapter.dispatch('play_time_secs_base_this_run', 'snowplow_media_player')()) }}
+{% endmacro %}
+
+{% macro default__play_time_secs_base_this_run() %}
+
+  coalesce(s.media_session_time_played, d.play_time_secs)
+
+{% endmacro %}

--- a/models/media_base/scratch/snowplow_media_player_base_this_run.sql
+++ b/models/media_base/scratch/snowplow_media_player_base_this_run.sql
@@ -195,10 +195,6 @@ events_this_run as (
 
 )
 
-{% set play_time_secs -%}
-  coalesce(s.media_session_time_played, d.play_time_secs)
-{%- endset %}
-
 select
   d.play_id,
   pv.page_view_id,
@@ -235,7 +231,7 @@ select
   ) as avg_playback_rate,
 
   -- time spent
-  {{ play_time_secs }} as play_time_secs,
+  {{ play_time_secs_base_this_run() }} as play_time_secs,
   coalesce(s.media_session_time_played_muted, d.play_time_muted_secs) as play_time_muted_secs,
   s.media_session_time_paused as paused_time_secs,
   s.media_session_time_buffering as buffering_time_secs,
@@ -251,7 +247,7 @@ select
   -- playback progress
   d.plays > 0 as is_played,
   case
-    when {{ play_time_secs }} > {{ var("snowplow__valid_play_sec") }} then true else
+    when {{ play_time_secs_base_this_run() }} > {{ var("snowplow__valid_play_sec") }} then true else
       false
   end as is_valid_play,
   case


### PR DESCRIPTION
## Description & motivation
There has been a request from users to be able to decide how to calculate the play_time_secs within the base_this_run table to handle edge cases in tracking. This release enables this via a new dispatch macro called `play_time_secs_base_this_run()` where users will be free to override the reference.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable ([PR](https://github.com/snowplow/documentation/pull/1448/files))

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

