### PR TITLE
Update for dbt 1.10

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,13 +1,11 @@
 ---
 name: Question
-about: A more general question about the package. Consider using discourse if more applicable.
+about: A more general question about the package.
 title: ''
 labels: type:question
 assignees: ''
 
 ---
-
-<!-- Please consider if your question would be better placed on the Snowplow Discourse (https://discourse.snowplow.io/) for more open conversations -->
 
 ### Question
 <!-- What is your question -->

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -92,9 +92,16 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
+      # Remove '*' and replace '.' with '_' in DBT_VERSION & set as SCHEMA_SUFFIX.
+      # SCHEMA_SUFFIX allows us to run multiple versions of dbt in parallel without overwriting the output tables
+      - name: Set SCHEMA_SUFFIX env
+        run: echo "SCHEMA_SUFFIX=$(echo ${DBT_VERSION%.*} | tr . _)" >> $GITHUB_ENV
+        env:
+          DBT_VERSION: ${{ matrix.dbt_version }}
       - name: Configure Docker credentials
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_SNOWPLOWCI_READ_USERNAME }}
           password: ${{ secrets.DOCKERHUB_SNOWPLOWCI_READ_PASSWORD }}
@@ -114,13 +121,6 @@ jobs:
           echo "WAREHOUSE_SPECIFIC=${WAREHOUSE_SPECIFIC}" >> $GITHUB_ENV
           echo "warehouse_platform=${WAREHOUSE_PLATFORM}" >> $GITHUB_OUTPUT
           echo "warehouse_specific=${WAREHOUSE_SPECIFIC}" >> $GITHUB_OUTPUT
-      # Remove '*' and replace '.' with '_' in DBT_VERSION & set as SCHEMA_SUFFIX.
-      # SCHEMA_SUFFIX allows us to run multiple versions of dbt in parallel without overwriting the output tables
-      - name: Set SCHEMA_SUFFIX env
-        run: echo "SCHEMA_SUFFIX=$(echo ${DBT_VERSION%.*} | tr . _)" >> $GITHUB_ENV
-        env:
-          DBT_VERSION: ${{ matrix.dbt_version }}
-
       - name: Set DEFAULT_TARGET env
         run: |
          echo "DEFAULT_TARGET=${{matrix.warehouse}}" >> $GITHUB_ENV
@@ -128,7 +128,7 @@ jobs:
       - name: Python setup
         uses: actions/setup-python@v4
         with:
-         python-version: "3.8.x"
+         python-version: "3.10.x"
 
       - name: Pip cache
         uses: actions/cache@v3
@@ -162,7 +162,7 @@ jobs:
       - name: Build and start Spark cluster
         working-directory: .github/workflows/spark_deployment
         run: |
-          docker-compose up -d
+          docker-compose up -d --build
           echo "Waiting for Spark services to start..."
           sleep 90
         if: ${{env.WAREHOUSE_PLATFORM == 'spark'}}

--- a/.github/workflows/spark_deployment/Dockerfile
+++ b/.github/workflows/spark_deployment/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre
 
 # Set environment variables
-ENV SPARK_VERSION=3.5.1
+ENV SPARK_VERSION=3.5.8
 ENV HADOOP_VERSION=3.3.4
 ENV ICEBERG_VERSION=1.4.2
 ENV AWS_SDK_VERSION=1.12.581

--- a/.github/workflows/spark_deployment/docker-compose.yml
+++ b/.github/workflows/spark_deployment/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   spark-master:
-    image: snowplow/spark-s3-iceberg:latest
+    build: .
     command: ["/bin/bash", "-c", "/spark/sbin/start-master.sh -h spark-master --properties-file /spark/conf/spark-defaults.conf && tail -f /spark/logs/spark--org.apache.spark.deploy.master.Master-1-*.out"]
     hostname: spark-master
     ports:
@@ -28,7 +28,7 @@ services:
       - spark-network
 
   spark-worker:
-    image: snowplow/spark-s3-iceberg:latest
+    build: .
     command: ["/bin/bash", "-c", "sleep 10 && /spark/sbin/start-worker.sh spark://spark-master:7077 --properties-file /spark/conf/spark-defaults.conf && tail -f /spark/logs/spark--org.apache.spark.deploy.worker.Worker-*.out"]
     depends_on:
       - spark-master
@@ -49,7 +49,7 @@ services:
       - spark-network
 
   thrift-server:
-    image: snowplow/spark-s3-iceberg:latest
+    build: .
     command: ["/bin/bash", "-c", "sleep 30 && /spark/sbin/start-thriftserver.sh --master spark://spark-master:7077 --driver-memory 2g --executor-memory 3g --hiveconf hive.server2.thrift.port=10000 --hiveconf hive.server2.thrift.bind.host=0.0.0.0 --conf spark.sql.hive.thriftServer.async=true --conf spark.sql.hive.thriftServer.workerQueue.size=2000 --conf spark.sql.hive.thriftServer.maxWorkerThreads=100 --conf spark.sql.hive.thriftServer.minWorkerThreads=50 && tail -f /spark/logs/spark--org.apache.spark.sql.hive.thriftserver.HiveThriftServer2-*.out"]
     ports:
       - '10000:10000'

--- a/.github/workflows/spark_deployment/spark-defaults.conf
+++ b/.github/workflows/spark_deployment/spark-defaults.conf
@@ -9,8 +9,6 @@ spark.sql.defaultCatalog                       glue
 spark.sql.catalog.glue.database                dbt-spark-iceberg
 
 spark.hadoop.fs.s3a.impl                       org.apache.hadoop.fs.s3a.S3AFileSystem
-spark.hadoop.fs.s3a.access.key                 <AWS_ACCESS_KEY_ID>
-spark.hadoop.fs.s3a.secret.key                 <AWS_SECRET_ACCESS_KEY>
 spark.hadoop.fs.s3a.endpoint                   s3.eu-west-1.amazonaws.com
 spark.hadoop.fs.s3a.path.style.access          true
 spark.hadoop.fs.s3a.region                     eu-west-1
@@ -18,6 +16,8 @@ spark.hadoop.fs.s3a.aws.region                 eu-west-1
 
 # Enabling AWS SDK V4 signing (required for regions launched after January 2014)
 spark.hadoop.com.amazonaws.services.s3.enableV4 true
+spark.hadoop.fs.s3a.access.key                 <AWS_ACCESS_KEY_ID>
+spark.hadoop.fs.s3a.secret.key                 <AWS_SECRET_ACCESS_KEY>
 spark.hadoop.fs.s3a.aws.credentials.provider   org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 
 # Hive Metastore Configuration (using AWS Glue)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,51 +1,15 @@
 # Contributing to `dbt-snowplow-*`
 
-`dbt-snowplow-*` are open source software. This means not only is the code available for you to view in it's entirety, but that you can contribute to the package in a multitude of ways. Whether you are a seasoned open source contributor or a first-time committer, we welcome and encourage you to contribute code (via Pull Request), documentation (via our docusaurus site), ideas (via Discussions for larger ideas, or issues for specific feature requests), or reporting bugs (via issues) to this project. Remember, fixing a typo makes you an Open Source Contributor. You can also contribute via topics on our [Discourse](https://discourse.snowplow.io/).
-
-Before you start a load of work, please note that all Pull Requests (apart from cosmetic fixes like typos) should be associated with an issue that has been approved for development by a maintainer. This is to stop you doing lots of development that may not be accepted into the package for a variety of reasons. Make sure to either [raise an issue](/../../issues/new) yourself or look at the existing issues before starting any development.
+This document is a guide for making code changes to `dbt-snowplow-*` packages. It assumes familiarity with dbt package development and basic Python tooling (virtualenvs, `pip`). Specific commands assume macOS or Linux.
 
 1. [Contributing to `dbt-snowplow-*`](#contributing-to-dbt-snowplow-)
-   1. [About this document](#about-this-document)
-      1. [Notes](#notes)
-   2. [Getting the code](#getting-the-code)
-      1. [Installing git](#installing-git)
-      2. [External contributors](#external-contributors)
-      3. [Snowplow contributors](#snowplow-contributors)
-   3. [Setting up an environment](#setting-up-an-environment)
-   4. [Implementation guidelines](#implementation-guidelines)
-   5. [Testing](#testing)
-   6. [Adding CHANGELOG Entry](#adding-changelog-entry)
-   7. [Submitting a Pull Request](#submitting-a-pull-request)
+   1. [Setting up an environment](#setting-up-an-environment)
+   2. [Implementation guidelines](#implementation-guidelines)
+   3. [Testing](#testing)
+   4. [Adding a CHANGELOG entry](#adding-a-changelog-entry)
+   5. [Submitting a Pull Request](#submitting-a-pull-request)
 
-## About this document
-
-This document serves as guide for contributing code changes to `dbt-snowplow-*` (this and similar repositories). It is not intended as a guide for using `dbt-snowplow-*`, and some pieces assume a level of familiarity with Python development (virtualenvs, `pip`, etc) and dbt package development. Specific code snippets in this guide assume you are using macOS or Linux and are comfortable with the command line.
-
-### Notes
-
-- **CLA:** If this is your first time contributing you will be asked to sign the Individual Contributor License Agreement. If you would prefer to read this in advance of submitting your Pull Request you can find it [here](https://docs.google.com/forms/d/e/1FAIpQLSd89YTDQ1XpTZbj3LpOkquV_h1Y8k9ay3iFbJsZsJrz18I23Q/viewform). If you are unable to sign the CLA, the `dbt-snowplow-*` maintainers will unfortunately be unable to merge any of your Pull Requests. We welcome you to participate in discussions, open issues, and comment on existing ones.
-- **Branches:** All Pull Requests from community contributors should target the `main` branch (default) and the maintainers will create the appropriate branch to merge this into. Please let us know if you believe your changes are a breaking change or could be done as part of a patch release, if you are unsure that's fine just make that clear in your Pull Request.
-- **Documentation:** The majority of the documentation for our dbt packages is in the core [Snowplow Docs](https://github.com/snowplow/documentation) and as such a Pull Request will need to be raised there to update any docs related to your change. Things such as the deployed dbt site are taken care of automatically.
-
-## Getting the code
-
-### Installing git
-
-You will need `git` in order to download and modify the `dbt-snowplow-*` source code. On macOS, the best way to download git is to just install [Xcode](https://developer.apple.com/support/xcode/).
-
-### External contributors
-
-If you are not a member of the `snowplow` GitHub organization, you can contribute to `dbt-snowplow-*` by forking the relevant package repository. For a detailed overview on forking, check out the [GitHub docs on forking](https://help.github.com/en/articles/fork-a-repo). In short, you will need to:
-
-1. Fork this repository
-2. Clone your fork locally
-3. Check out a new branch for your proposed changes
-4. Push changes to your fork
-5. Open a Pull Request against this repo from your forked repository
-
-### Snowplow contributors
-
-If you are a member of the `snowplow` GitHub organization, you will have push access to this repo. Rather than forking to make your changes, just clone the repository, check out a new branch, and push directly to that branch.
+Documentation for our dbt packages lives in the core [Snowplow Docs](https://github.com/snowplow/documentation); any change that affects user-facing behaviour needs a matching PR there.
 
 ## Setting up an environment
 
@@ -102,7 +66,7 @@ Tests are of 1 of 2 kinds:
 To run the integration tests:
 1. Ensure the `integration_tests` folder is your working directory (you may need to `cd integration_tests`)
 2. Run `dbt run-operation post_ci_cleanup` to ensure a clean set of schemas (this will drop the schemas we use, so ensure your profile is only for these tests)
-3. Run `./.scripts/integration_test.sh -d {target}` with your target name
+3. Run `./.scripts/integration_tests.sh -d {target}` with your target name
 4. Ensure all tests run successfully
 
 If any tests fail, you should examine the outputs and either correct the test or correct your changes.
@@ -117,8 +81,4 @@ You don't need to worry about which version your change will go into. Just creat
 
 ## Submitting a Pull Request
 
-A  maintainer will review your Pull Request. They may suggest code revision for style or clarity, or request that you add unit or integration test(s). We promise these are good things and it's not personal, we all want to make sure the highest quality of work goes into the packages in a way that will be the least disruptive for our users.
-
-Automated tests run via Github actions. If you're a first-time contributor, all tests (including code checks and unit tests) will require a maintainer to approve. You will not be able to see the output data of these tests, but we can share and explore any failures with you should there be any.
-
-Once all tests are passing and your Pull Request has been approved, a maintainer will merge your changes into the active development branch. And that's it! You're now an Open Source Contributor!
+Open the PR against `main`. Flag in the description whether you believe the change is a patch, minor, or major release (if unsure, say so). Automated tests run via GitHub Actions; once they pass and the PR is approved, a maintainer will merge it into the active development branch.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![early-release]][tracker-classification] [![License][license-image]][license] [![Discourse posts][discourse-image]][discourse]
+[![early-release]][tracker-classification] [![License][license-image]][license]
 
 ![snowplow-logo](https://raw.githubusercontent.com/snowplow/dbt-snowplow-utils/main/assets/snowplow_logo.png)
 
@@ -67,8 +67,6 @@ Please refer to the [dbt doc site][snowplow-media-player-docs-dbt] for details o
 
 We welcome all ideas, questions and contributions!
 
-For support requests, please use our community support [Discourse][discourse] forum.
-
 If you find a bug, please report an issue on GitHub.
 
 # Copyright and license
@@ -116,9 +114,6 @@ limitations under the License.
 [mobile-tracking]: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/media-tracking/
 
 [dbt-package-docs]: https://docs.getdbt.com/docs/building-a-dbt-project/package-management
-
-[discourse-image]: https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdiscourse.snowplow.io%2F
-[discourse]: http://discourse.snowplow.io/
 
 [snowplow-media-player-docs-dbt]: https://snowplow.github.io/dbt-snowplow-media-player/#!/overview/snowplow_media_player
 [snowplow-media-player-docs]: https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-media-player-data-model/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'snowplow_media_player'
 version: '0.9.4'
 config-version: 2
 
-require-dbt-version: ['>=1.4.0', '<2.0.0']
+require-dbt-version: ['>=1.10.6', '<2.0.0']
 
 profile: 'default'
 
@@ -17,8 +17,6 @@ seed-paths: ['seeds']
 macro-paths: ['macros']
 docs-paths: ['docs']
 snapshot-paths: ['snapshots']
-
-target-path: 'target'
 clean-targets:
   - 'target'
   - 'dbt_packages'
@@ -126,15 +124,15 @@ models:
         +schema: 'scratch'
         +tags: 'scratch'
         bigquery:
-          +enabled: '{{ target.type == "bigquery" | as_bool() }}'
+          +enabled: '{{ (target.type == "bigquery") | as_bool() }}'
         databricks:
-          +enabled: '{{ target.type == "databricks" | as_bool() }}'
+          +enabled: '{{ (target.type == "databricks") | as_bool() }}'
         default:
-          +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+          +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         snowflake:
-          +enabled: '{{ target.type == "snowflake" | as_bool() }}'
+          +enabled: '{{ (target.type == "snowflake") | as_bool() }}'
         spark:
-          +enabled: '{{ target.type == "spark" | as_bool() }}'
+          +enabled: '{{ (target.type == "spark") | as_bool() }}'
     media_base:
       +schema: 'derived'
       +tags: 'snowplow_media_player_incremental'
@@ -160,3 +158,5 @@ models:
     media_ads:
       +schema: 'derived'
       +tags: 'snowplow_media_player_incremental'
+flags:
+  require_generic_test_arguments_property: true

--- a/docs/markdown/snowplow_media_player_overview.md
+++ b/docs/markdown/snowplow_media_player_overview.md
@@ -30,8 +30,6 @@ Check [dbt Hub](https://hub.getdbt.com/snowplow/snowplow_media_player/latest/) f
 
 We welcome all ideas, questions and contributions!
 
-For support requests, please use our community support [Discourse][discourse] forum.
-
 If you find a bug, please report an issue on GitHub.
 
 # Copyright and license
@@ -72,9 +70,6 @@ limitations under the License.
 [selectors-yml-file]: https://github.com/
 
 [dbt-package-docs]: https://docs.getdbt.com/docs/building-a-dbt-project/package-management
-
-[discourse-image]: https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdiscourse.snowplow.io%2F
-[discourse]: http://discourse.snowplow.io/
 
 [snowplow-media-player-docs]: https://snowplow.github.io/dbt-snowplow-media-player/#!/overview/snowplow_media_player
 

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -2,3 +2,5 @@
 target/
 dbt_modules/
 logs/
+dbt_internal_packages/
+.user.yml

--- a/integration_tests/ci/profiles.yml
+++ b/integration_tests/ci/profiles.yml
@@ -2,10 +2,6 @@
 # HEY! This file is used in the Snowplow dbt Media Player integration tests.
 # You should __NEVER__ check credentials into version control. Thanks for reading :)
 
-config:
-    send_anonymous_usage_stats: False
-    use_colors: True
-
 integration_tests:
   target: "{{ env_var('DEFAULT_TARGET') }}"
   outputs:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -13,12 +13,10 @@ analysis-paths: ['analysis']
 test-paths: ['tests']
 seed-paths: ['data']
 macro-paths: ['macros']
-
-target-path: 'target'
 clean-targets:
-    - 'target'
-    - 'dbt_modules'
-    - 'dbt_packages'
+  - 'target'
+  - 'dbt_modules'
+  - 'dbt_packages'
 
 quoting:
   identifier: false
@@ -26,20 +24,20 @@ quoting:
 
 models:
   snowplow_media_player_integration_tests:
-    bind: false
     +materialized: table
     +schema: 'snplw_media_player_int_tests'
     source:
       bigquery:
-        +enabled: '{{ target.type == "bigquery" | as_bool() }}'
+        +enabled: '{{ (target.type == "bigquery") | as_bool() }}'
       databricks:
-        +enabled: '{{ target.type == "databricks" | as_bool() }}'
+        +enabled: '{{ (target.type == "databricks") | as_bool() }}'
       spark:
-        +enabled: '{{ target.type == "spark" | as_bool() }}'
+        +enabled: '{{ (target.type == "spark") | as_bool() }}'
       default:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
       snowflake:
-        +enabled: '{{ target.type == "snowflake" | as_bool() }}'
+        +enabled: '{{ (target.type == "snowflake") | as_bool() }}'
+    +bind: false
   snowplow_media_player:
     +persist_docs:
       relation: '{{ false if target.type in ["spark","databricks"] else true }}'
@@ -77,7 +75,6 @@ vars:
     snowplow__ad_views_passthroughs: ['v_collector', {'sql': 'v_tracker || app_id', 'alias': 'tracker_app_id'}]
 
 seeds:
-  quote_columns: false
   snowplow_media_player_integration_tests:
     +schema: 'snplw_media_player_int_tests'
     source:
@@ -102,12 +99,12 @@ seeds:
           mkt_content: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           se_label: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           se_property: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          se_value: float
+          se_value: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           tr_orderid: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           tr_affiliation: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          tr_total: float
-          tr_tax: float
-          tr_shipping: float
+          tr_total: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          tr_tax: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          tr_shipping: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           tr_city: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           tr_state: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           tr_country: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
@@ -115,7 +112,7 @@ seeds:
           ti_sku: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           ti_name: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           ti_category: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          ti_price: float
+          ti_price: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           br_name: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           br_family: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           br_version: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
@@ -128,11 +125,11 @@ seeds:
           dvce_type: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           dvce_ismobile: boolean
           tr_currency: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          tr_total_base: float
-          tr_tax_base: float
-          tr_shipping_base: float
+          tr_total_base: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          tr_tax_base: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          tr_shipping_base: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           ti_currency: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          ti_price_base: float
+          ti_price_base: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           base_currency: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           etl_tags: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           dvce_sent_tstamp: timestamp
@@ -142,88 +139,88 @@ seeds:
           load_tstamp: timestamp
 
       com_snowplowanalytics_snowplow_media_player_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
-          current_time: float
+          current_time: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           percent_progress: integer
-          duration: float
+          duration: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
 
       com_snowplowanalytics_snowplow_media_player_2:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
-          current_time: float
-          duration: float
+          current_time: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          duration: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           quality: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
 
       com_snowplowanalytics_snowplow_media_session_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
-          content_watched: float
+          content_watched: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
 
       com_snowplowanalytics_snowplow_media_ad_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
           pod_position: integer
 
       com_snowplowanalytics_snowplow_media_ad_break_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       com_snowplowanalytics_snowplow_media_ad_quartile_event_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       org_whatwg_media_element_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
-          default_playback_rate: float
+          default_playback_rate: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
 
       org_whatwg_video_element_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       com_snowplowanalytics_snowplow_media_player_event_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       com_youtube_youtube_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       com_snowplowanalytics_snowplow_web_page_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       com_snowplowanalytics_mobile_screen_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
 
       com_snowplowanalytics_snowplow_client_session_1:
-        +enabled: '{{ target.type in ["redshift", "postgres"] | as_bool() }}'
+        +enabled: '{{ (target.type in ["redshift", "postgres"]) | as_bool() }}'
         +quote_columns: true
         +column_types:
           root_tstamp: timestamp
@@ -250,17 +247,17 @@ seeds:
           os_name: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           os_timezone: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           platform: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          duration_secs: float
+          duration_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           media_type: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           media_player_type: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           start_tstamp: timestamp
           end_tstamp: timestamp
-          avg_playback_rate: float
-          play_time_secs: float
-          play_time_muted_secs: float
-          paused_time_secs: float
-          buffering_time_secs: float
-          ads_time_secs: float
+          avg_playback_rate: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          play_time_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          play_time_muted_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          paused_time_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          buffering_time_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          ads_time_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           seeks: integer
           ads: integer
           ads_clicked: integer
@@ -269,33 +266,33 @@ seeds:
           is_played: boolean
           is_valid_play: boolean
           is_complete_play: boolean
-          retention_rate: float
+          retention_rate: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           percent_progress_reached: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          content_watched_secs: float
-          content_watched_percent: float
+          content_watched_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          content_watched_percent: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
 
       snowplow_media_player_media_stats_expected:
         +column_types:
           media_identifier: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           player_id: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           media_label: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          duration_secs: float
+          duration_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           media_type: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           media_player_type: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          play_time_mins: float
-          avg_play_time_mins: float
-          avg_content_watched_mins: float
+          play_time_mins: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          avg_play_time_mins: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          avg_content_watched_mins: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           first_play: timestamp
           last_play: timestamp
           plays: integer
           valid_plays: integer
           complete_plays: integer
           impressions: integer
-          avg_playback_rate: float
-          play_rate: float
-          completion_rate_by_plays: float
-          avg_percent_played: float
-          avg_retention_rate: float
+          avg_playback_rate: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          play_rate: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          completion_rate_by_plays: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          avg_percent_played: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
+          avg_retention_rate: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           last_base_tstamp: timestamp
           percent_reached_10: integer
           percent_reached_25: integer
@@ -321,7 +318,7 @@ seeds:
           ad_id: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           name: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           creative_id: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          duration_secs: float
+          duration_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           skippable: boolean
           pod_position: integer
           clicked: boolean
@@ -340,7 +337,7 @@ seeds:
           ad_id: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           name: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           creative_id: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
-          duration_secs: float
+          duration_secs: "{{ 'float64' if target.type in ['bigquery'] else 'float' }}"
           skippable: boolean
           pod_position: integer
           views: integer
@@ -359,3 +356,8 @@ seeds:
           percent_reached_100_unique: integer
           first_view: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
           last_view: '{{ "string" if target.type in ["bigquery", "databricks", "spark"] else "varchar" }}'
+  +quote_columns: false
+flags:
+  require_generic_test_arguments_property: true
+  send_anonymous_usage_stats: false
+  use_colors: true

--- a/integration_tests/models/actual/actual_vs_expected.yml
+++ b/integration_tests/models/actual/actual_vs_expected.yml
@@ -4,146 +4,154 @@ models:
   - name: snowplow_media_player_base_actual
     tests:
       - dbt_utils.equal_rowcount:
-          compare_model: ref('snowplow_media_player_base_expected_stg')
+          arguments:
+            compare_model: ref('snowplow_media_player_base_expected_stg')
       - dbt_utils.equality:
-          compare_model: ref('snowplow_media_player_base_expected_stg')
-          compare_columns:
-            - play_id
-            - page_view_id
-            - page_view_id_array
-            - media_identifier
-            - player_id
-            - media_label
-            - session_identifier
-            - domain_sessionid_array
-            - user_identifier
-            - user_id
-            - duration_secs
-            - media_type
-            - media_player_type
-            - page_referrer
-            - page_url
-            - source_url
-            - geo_region_name
-            - br_name
-            - dvce_type
-            - os_name
-            - os_timezone
-            - start_tstamp
-            - end_tstamp
-            - play_time_secs
-            - play_time_muted_secs
-            - paused_time_secs
-            - buffering_time_secs
-            - ads_time_secs
-            - is_played
-            - is_valid_play
-            - is_complete_play
-            - avg_playback_rate
-            - retention_rate
-            - seeks
-            - ads
-            - ads_clicked
-            - ads_skipped
-            - ad_breaks
-            - percent_progress_reached
-            - content_watched_secs
-            - content_watched_percent
+          arguments:
+            compare_model: ref('snowplow_media_player_base_expected_stg')
+            compare_columns:
+              - play_id
+              - page_view_id
+              - page_view_id_array
+              - media_identifier
+              - player_id
+              - media_label
+              - session_identifier
+              - domain_sessionid_array
+              - user_identifier
+              - user_id
+              - duration_secs
+              - media_type
+              - media_player_type
+              - page_referrer
+              - page_url
+              - source_url
+              - geo_region_name
+              - br_name
+              - dvce_type
+              - os_name
+              - os_timezone
+              - start_tstamp
+              - end_tstamp
+              - play_time_secs
+              - play_time_muted_secs
+              - paused_time_secs
+              - buffering_time_secs
+              - ads_time_secs
+              - is_played
+              - is_valid_play
+              - is_complete_play
+              - avg_playback_rate
+              - retention_rate
+              - seeks
+              - ads
+              - ads_clicked
+              - ads_skipped
+              - ad_breaks
+              - percent_progress_reached
+              - content_watched_secs
+              - content_watched_percent
 
   - name: snowplow_media_player_media_stats_actual
     tests:
       - dbt_utils.equal_rowcount:
-          compare_model: ref('snowplow_media_player_media_stats_expected_stg')
+          arguments:
+            compare_model: ref('snowplow_media_player_media_stats_expected_stg')
       - dbt_utils.equality:
-          compare_model: ref('snowplow_media_player_media_stats_expected_stg')
-          compare_columns:
-            - media_identifier
-            - player_id
-            - media_label
-            - duration_secs
-            - media_type
-            - media_player_type
-            - play_time_mins
-            - avg_play_time_mins
-            - avg_content_watched_mins
-            - first_play
-            - last_play
-            - plays
-            - valid_plays
-            - complete_plays
-            - impressions
-            - completion_rate_by_plays
-            - percent_reached_10
-            - percent_reached_25
-            - percent_reached_50
-            - percent_reached_75
-            - percent_reached_100
-            - avg_playback_rate
-            - play_rate
-            - avg_percent_played
-            - avg_retention_rate
+          arguments:
+            compare_model: ref('snowplow_media_player_media_stats_expected_stg')
+            compare_columns:
+              - media_identifier
+              - player_id
+              - media_label
+              - duration_secs
+              - media_type
+              - media_player_type
+              - play_time_mins
+              - avg_play_time_mins
+              - avg_content_watched_mins
+              - first_play
+              - last_play
+              - plays
+              - valid_plays
+              - complete_plays
+              - impressions
+              - completion_rate_by_plays
+              - percent_reached_10
+              - percent_reached_25
+              - percent_reached_50
+              - percent_reached_75
+              - percent_reached_100
+              - avg_playback_rate
+              - play_rate
+              - avg_percent_played
+              - avg_retention_rate
 
   - name: snowplow_media_player_media_ad_views_actual
     tests:
       - dbt_utils.equal_rowcount:
-          compare_model: ref('snowplow_media_player_media_ad_views_expected_stg')
+          arguments:
+            compare_model: ref('snowplow_media_player_media_ad_views_expected_stg')
       - dbt_utils.equality:
-          compare_model: ref('snowplow_media_player_media_ad_views_expected_stg')
-          compare_columns:
-            - media_ad_view_id
-            - media_ad_id
-            - platform
-            - media_identifier
-            - media_label
-            - user_identifier
-            - session_identifier
-            - domain_sessionid_array
-            - user_id
-            - play_id
-            - ad_break_id
-            - ad_break_name
-            - ad_break_type
-            - ad_id
-            - name
-            - creative_id
-            - duration_secs
-            - pod_position
-            - skippable
-            - clicked
-            - skipped
-            - percent_reached_25
-            - percent_reached_50
-            - percent_reached_75
-            - percent_reached_100
+          arguments:
+            compare_model: ref('snowplow_media_player_media_ad_views_expected_stg')
+            compare_columns:
+              - media_ad_view_id
+              - media_ad_id
+              - platform
+              - media_identifier
+              - media_label
+              - user_identifier
+              - session_identifier
+              - domain_sessionid_array
+              - user_id
+              - play_id
+              - ad_break_id
+              - ad_break_name
+              - ad_break_type
+              - ad_id
+              - name
+              - creative_id
+              - duration_secs
+              - pod_position
+              - skippable
+              - clicked
+              - skipped
+              - percent_reached_25
+              - percent_reached_50
+              - percent_reached_75
+              - percent_reached_100
 
   - name: snowplow_media_player_media_ads_actual
     tests:
       - dbt_utils.equal_rowcount:
-          compare_model: ref('snowplow_media_player_media_ads_expected_stg')
+          arguments:
+            compare_model: ref('snowplow_media_player_media_ads_expected_stg')
       - dbt_utils.equality:
-          compare_model: ref('snowplow_media_player_media_ads_expected_stg')
-          compare_columns:
-            - media_ad_id
-            - platform
-            - media_identifier
-            - media_label
-            - ad_id
-            - name
-            - creative_id
-            - duration_secs
-            - skippable
-            - pod_position
-            - views
-            - clicked
-            - skipped
-            - percent_reached_25
-            - percent_reached_50
-            - percent_reached_75
-            - percent_reached_100
-            - views_unique
-            - clicked_unique
-            - skipped_unique
-            - percent_reached_25_unique
-            - percent_reached_50_unique
-            - percent_reached_75_unique
-            - percent_reached_100_unique
+          arguments:
+            compare_model: ref('snowplow_media_player_media_ads_expected_stg')
+            compare_columns:
+              - media_ad_id
+              - platform
+              - media_identifier
+              - media_label
+              - ad_id
+              - name
+              - creative_id
+              - duration_secs
+              - skippable
+              - pod_position
+              - views
+              - clicked
+              - skipped
+              - percent_reached_25
+              - percent_reached_50
+              - percent_reached_75
+              - percent_reached_100
+              - views_unique
+              - clicked_unique
+              - skipped_unique
+              - percent_reached_25_unique
+              - percent_reached_50_unique
+              - percent_reached_75_unique
+              - percent_reached_100_unique

--- a/integration_tests/models/actual/snowplow_media_player_base_actual.sql
+++ b/integration_tests/models/actual/snowplow_media_player_base_actual.sql
@@ -14,7 +14,9 @@ select
         'avg_playback_rate',
         'retention_rate',
         'content_watched_secs',
-        'content_watched_percent'
+        'content_watched_percent',
+        '_partitiontime',
+        '_partitiondate'
     ] %}{{ col.name }}, {% endfor %}
 
     round(cast(play_time_secs as {{ type_numeric() }}), 3) as play_time_secs,

--- a/integration_tests/models/actual/snowplow_media_player_media_stats_actual.sql
+++ b/integration_tests/models/actual/snowplow_media_player_media_stats_actual.sql
@@ -16,7 +16,9 @@ select
         'avg_percent_played',
         'play_rate',
         'completion_rate_by_plays',
-        'avg_retention_rate'
+        'avg_retention_rate',
+        '_partitiontime',
+        '_partitiondate'
     ] %}{{ col.name }}, {% endfor %}
 
     round(cast(play_time_mins as {{ type_numeric() }}), 3) as play_time_mins,

--- a/integration_tests/models/expected/snowplow_media_player_base_expected_stg.sql
+++ b/integration_tests/models/expected/snowplow_media_player_base_expected_stg.sql
@@ -17,7 +17,9 @@ select
         'paused_time_secs',
         'buffering_time_secs',
         'ads_time_secs',
-        'content_watched_percent'
+        'content_watched_percent',
+        '_partitiontime',
+        '_partitiondate'
     ] and not col.name.lower().endswith('_date') %}{{ col.name }}, {% endfor %}
 
     round(cast(play_time_secs as {{ type_numeric() }}), 3) as play_time_secs,

--- a/integration_tests/models/expected/snowplow_media_player_media_stats_expected_stg.sql
+++ b/integration_tests/models/expected/snowplow_media_player_media_stats_expected_stg.sql
@@ -16,7 +16,9 @@ select
         'avg_percent_played',
         'play_rate',
         'completion_rate_by_plays',
-        'avg_retention_rate'
+        'avg_retention_rate',
+        '_partitiontime',
+        '_partitiondate'
     ] and not col.name.lower().endswith('_date') %}{{ col.name }}, {% endfor %}
 
     round(cast(play_time_mins as {{ type_numeric() }}), 3) as play_time_mins,

--- a/models/base/manifest/base_manifest.yml
+++ b/models/base/manifest/base_manifest.yml
@@ -6,11 +6,12 @@ models:
     columns:
       - name: session_identifier
         description: '{{ doc("col_session_identifier") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: user_identifier
         description: '{{ doc("col_domain_userid") }}'
       - name: start_tstamp
@@ -26,11 +27,12 @@ models:
     columns:
       - name: model
         description: The name of the model.
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: last_success
         description: The timestamp of the latest event consumed by the model, based on `collector_tstamp`
   - name: snowplow_media_player_base_quarantined_sessions
@@ -38,8 +40,9 @@ models:
     columns:
       - name: session_identifier
         description: The `session_id` of the quarantined session
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key

--- a/models/base/manifest/snowplow_media_player_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowplow_media_player_base_sessions_lifecycle_manifest.sql
@@ -1,23 +1,20 @@
-{{
-  config(
-    materialized="incremental",
-    unique_key='session_identifier',
-    upsert_date_key='start_tstamp',
-    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
+{{ config(
+    materialized="incremental", 
+    unique_key='session_identifier', 
+    partition_by=snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_val='start_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_identifier"], snowflake_val=["to_date(start_tstamp)"]),
-    full_refresh=snowplow_media_player.allow_refresh(),
-    tags=["manifest"],
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    }, databricks_val='start_tstamp_date'), 
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_identifier"], snowflake_val=["to_date(start_tstamp)"]), 
+    full_refresh=snowplow_media_player.allow_refresh(), 
+    tags=["manifest"], 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')), 
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    },
-    snowplow_optimize=true
-  )
-}}
+    }, 
+    meta={'upsert_date_key': 'start_tstamp', 'snowplow_optimize': true}
+) }}
 
 {% set sessions_lifecycle_manifest_query = snowplow_utils.base_create_snowplow_sessions_lifecycle_manifest(
     session_identifiers=session_identifiers(),

--- a/models/base/scratch/base_scratch.yml
+++ b/models/base/scratch/base_scratch.yml
@@ -14,11 +14,12 @@ models:
     columns:
       - name: session_identifier
         description: '{{ doc("col_session_identifier") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: user_identifier
         description: '{{ doc("col_user_identifier") }}'
       - name: start_tstamp
@@ -31,11 +32,12 @@ models:
     columns:
       - name: event_id
         description: '{{ doc("col_event_id") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: page_view_id
         description: '{{ doc("col_page_view_id") }}'
       - name: original_session_identifier
@@ -58,7 +60,8 @@ models:
         description: '{{ doc("col_duration_secs") }}'
         tests:
           - dbt_utils.expression_is_true:
-              expression: "> 0"
+              arguments:
+                expression: "> 0"
       - name: media_type
         description: '{{ doc("col_media_type") }}'
       - name: media_player_type
@@ -155,10 +158,11 @@ models:
     columns:
       - name: percent_progress
         description: '{{ doc("col_percent_progress") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: weight_rate
         description: '{{ doc("col_weight_rate") }}'

--- a/models/custom/snowplow_media_player_custom.yml
+++ b/models/custom/snowplow_media_player_custom.yml
@@ -2,16 +2,16 @@ version: 2
 
 models:
   - name: snowplow_media_player_session_stats
-    +tags: "snowplow_media_player_incremental"
     description: '{{ doc("table_session_stats") }}'
     columns:
       - name: domain_sessionid
         description: 'The first domain_sessionid from domain_sessionid_array'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: user_identifier
         description: '{{ doc("col_user_identifier") }}'
       - name: impressions
@@ -45,17 +45,20 @@ models:
       - name: complete_plays
         description: '{{ doc("col_complete_plays") }}'
 
+    config:
+      meta:
+        +tags: "snowplow_media_player_incremental"
   - name: snowplow_media_player_user_stats
-    +tags: "snowplow_media_player_incremental"
     description: '{{ doc("table_user_stats") }}'
     columns:
       - name: user_identifier
         description: '{{ doc("col_user_identifier") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: first_play
         description: '{{ doc("col_first_play") }}'
       - name: last_play
@@ -78,3 +81,6 @@ models:
         description: '{{ doc("col_avg_session_play_time_mins") }}'
       - name: avg_percent_played
         description: '{{ doc("col_avg_percent_played") }}'
+    config:
+      meta:
+        +tags: "snowplow_media_player_incremental"

--- a/models/media_ad_views/media_ad_views.yml
+++ b/models/media_ad_views/media_ad_views.yml
@@ -2,16 +2,16 @@ version: 2
 
 models:
   - name: snowplow_media_player_media_ad_views
-    +tags: "snowplow_media_player_incremental"
     description: '{{ doc("table_base") }}'
     columns:
       - name: media_ad_view_id
         description: The primary key of this table
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: media_ad_id
         description: '{{ doc("col_media_ad_id") }}'
         tests:
@@ -70,3 +70,6 @@ models:
         description: '{{ doc("col_last_event") }}'
       - name: domain_sessionid_array
         description: '{{ doc("col_domain_sessionid_array") }}'
+    config:
+      meta:
+        +tags: "snowplow_media_player_incremental"

--- a/models/media_ad_views/scratch/base_scratch.yml
+++ b/models/media_ad_views/scratch/base_scratch.yml
@@ -6,11 +6,12 @@ models:
     columns:
       - name: media_ad_view_id
         description: The primary key of this table
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: media_ad_id
         description: '{{ doc("col_media_ad_id") }}'
         tests:

--- a/models/media_ad_views/snowplow_media_player_media_ad_views.sql
+++ b/models/media_ad_views/snowplow_media_player_media_ad_views.sql
@@ -5,28 +5,25 @@ and you may not use this file except in compliance with the Snowplow Personal an
 You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
 
-{{
-  config(
-    materialized= "incremental",
-    unique_key= 'media_ad_view_id',
-    upsert_date_key='last_event',
-    sort = 'last_event',
-    dist = 'media_ad_id',
-    tags=["derived"],
-    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
+{{ config(
+    materialized="incremental", 
+    unique_key='media_ad_view_id', 
+    sort='last_event', 
+    dist='media_ad_id', 
+    tags=["derived"], 
+    partition_by=snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "viewed_at",
       "data_type": "timestamp"
-    }, databricks_val='viewed_at_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["media_ad_id"]),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    }, databricks_val='viewed_at_date'), 
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["media_ad_id"]), 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')), 
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    },
-    snowplow_optimize=true,
-    enabled=var('snowplow__enable_media_ad', false)
-  )
-}}
+    }, 
+    enabled=var('snowplow__enable_media_ad', false), 
+    meta={'upsert_date_key': 'last_event', 'snowplow_optimize': true}
+) }}
 
 select *
 

--- a/models/media_ads/media_ads.yml
+++ b/models/media_ads/media_ads.yml
@@ -6,11 +6,12 @@ models:
     columns:
       - name: media_ad_id
         description: 'The primary key of this table'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: platform
         description: '{{ doc("col_platform")}}'
       - name: media_identifier

--- a/models/media_base/media_base.yml
+++ b/models/media_base/media_base.yml
@@ -2,16 +2,16 @@ version: 2
 
 models:
   - name: snowplow_media_player_base
-    +tags: "snowplow_media_player_incremental"
     description: '{{ doc("table_base") }}'
     columns:
       - name: play_id
         description: '{{ doc("col_play_id") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: page_view_id
         description: '{{ doc("col_page_view_id") }}'
       - name: page_view_id_array
@@ -101,3 +101,6 @@ models:
         description: '{{ doc("col_content_watched_secs") }}'
       - name: content_watched_percent
         description: '{{ doc("col_content_watched_percent") }}'
+    config:
+      meta:
+        +tags: "snowplow_media_player_incremental"

--- a/models/media_base/scratch/base_scratch.yml
+++ b/models/media_base/scratch/base_scratch.yml
@@ -6,11 +6,12 @@ models:
     columns:
       - name: play_id
         description: '{{ doc("col_play_id") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: page_view_id
         description: '{{ doc("col_page_view_id") }}'
       - name: page_view_id_array

--- a/models/media_base/snowplow_media_player_base.sql
+++ b/models/media_base/snowplow_media_player_base.sql
@@ -5,27 +5,24 @@ and you may not use this file except in compliance with the Snowplow Personal an
 You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
 
-{{
-  config(
-    materialized= "incremental",
-    upsert_date_key='start_tstamp',
-    unique_key = 'play_id',
-    sort = 'start_tstamp',
-    dist = 'play_id',
-    tags=["derived"],
-    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
+{{ config(
+    materialized="incremental", 
+    unique_key='play_id', 
+    sort='start_tstamp', 
+    dist='play_id', 
+    tags=["derived"], 
+    partition_by=snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_val='start_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["media_identifier"]),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    }, databricks_val='start_tstamp_date'), 
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["media_identifier"]), 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')), 
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    },
-    snowplow_optimize=true
-  )
-}}
+    }, 
+    meta={'upsert_date_key': 'start_tstamp', 'snowplow_optimize': true}
+) }}
 
 select *
 

--- a/models/media_plays/media_plays.yml
+++ b/models/media_plays/media_plays.yml
@@ -2,16 +2,16 @@ version: 2
 
 models:
   - name: snowplow_media_player_plays_by_pageview
-    +tags: "snowplow_media_player_incremental"
     description: '{{ doc("table_plays_by_pageview") }}'
     columns:
       - name: play_id
         description: '{{ doc("col_play_id") }}'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: page_view_id
         description: '{{ doc("col_page_view_id") }}'
       - name: page_view_id_array
@@ -101,3 +101,6 @@ models:
         description: '{{ doc("col_content_watched_secs") }}'
       - name: content_watched_percent
         description: '{{ doc("col_content_watched_percent") }}'
+    config:
+      meta:
+        +tags: "snowplow_media_player_incremental"

--- a/models/media_stats/media_stats.yml
+++ b/models/media_stats/media_stats.yml
@@ -6,11 +6,12 @@ models:
     columns:
       - name: media_identifier
         description: 'The primary key of this table'
-        tags:
-          - primary-key
         tests:
           - unique
           - not_null
+        config:
+          tags:
+            - primary-key
       - name: player_id
         description: '{{ doc("col_player_id") }}'
       - name: media_label

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: [">=0.17.3", "<0.18.0"]
+    version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
Update for dbt 1.10

- Bumps require-dbt-version to >=1.10.6 and snowplow_utils to >=1.0.0
- Migrates project + model YAML to dbt 1.10's supported syntax
- Bumped to python 3.10 in CI, updated action versions
- Updates the Spark CI image
- Removes Discourse references from README/CONTRIBUTING/issue template

Tested on [1.10.6](https://github.com/snowplow/dbt-snowplow-media-player/actions/runs/25115300327) where all pass apart from redshift, and [1.10.20](https://github.com/snowplow/dbt-snowplow-media-player/actions/runs/25158213411/job/73746273656) where all pass.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have updated the CHANGELOG.md 
-->
