### PR TITLE
Fix CI docs generation

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Python setup
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8.x"
+        python-version: "3.12.x"
 
     - name: Pip cache
       uses: actions/cache@v3


### PR DESCRIPTION
Bumps python to 3.12.* to fix docs generation action

https://github.com/snowplow/dbt-snowplow-media-player/actions/runs/25485681421

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here)
