### PR TITLE
Release/dbt snowplow media player/1.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+snowplow-media-player 1.0.1 (2026-05-26)
+---------------------------------------
+## Summary
+This release fixes an inconsistent tracker behavior which produces NULL / "" values for the same media element which may result in duplicate values in the `snowplow_media_player_media_stats` table. It also fixes an inconsistency in the manifest table update due to a typo in the on-run-end hook.
+
+## Fixes
+- Normalize empty strings to null for surrogate key dims (Fix #93)
+- Update dbt_project.yml
+
+## Upgrading  
+Update the snowplow-media-player version in your packages.yml file.
+
 snowplow-media-player 1.0.0 (2026-05-06)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -108,7 +108,7 @@ on-run-start:
 
 # Update manifest table with last event consumed per successfully executed node/model
 on-run-end:
-  - '{{ snowplow_utils.snowplow_incremental_post_hook("snowplow_media_player", "snowplow_media_player_incremental_manifest", "snowplow_media_player_base_events_this_run", var("snowplow__session_tstamp", "collector_tstamp")) }}'
+  - '{{ snowplow_utils.snowplow_incremental_post_hook("snowplow_media_player", "snowplow_media_player_incremental_manifest", "snowplow_media_player_base_events_this_run", var("snowplow__session_timestamp", "collector_tstamp")) }}'
   - "{{ snowplow_utils.grant_usage_on_schemas_built_into(var('snowplow__grant_schemas', true)) }}"
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_media_player'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 
 require-dbt-version: ['>=1.10.6', '<2.0.0']

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_media_player_integration_tests'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/media_base/scratch/snowplow_media_player_base_this_run.sql
+++ b/models/media_base/scratch/snowplow_media_player_base_this_run.sql
@@ -37,15 +37,15 @@ events_this_run as (
   select
     i.play_id
     ,i.media_identifier
-    ,i.player_id
-    ,i.media_label
+    ,nullif(i.player_id, '') as player_id
+    ,nullif(i.media_label, '') as media_label
     ,i.session_identifier
     ,i.app_id
     ,i.user_identifier
     ,i.user_id
     ,i.platform
-    ,i.media_type
-    ,i.media_player_type
+    ,nullif(i.media_type, '') as media_type
+    ,nullif(i.media_player_type, '') as media_player_type
     ,i.page_referrer
     ,i.page_url
     ,i.geo_region_name


### PR DESCRIPTION
## Description & motivation
This release fixes an inconsistent tracker behavior which produces NULL / "" values for the same media element which may result in duplicate values in the `snowplow_media_player_media_stats` table. It also fixes an inconsistency in the manifest table update due to a typo in the on-run-end hook.


## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation/pull/1803) PR if applicable

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

