### PR TITLE
Remove redshift from CI

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         dbt_version: ["1.*"]
-        warehouse: ["postgres", "bigquery", "snowflake", "databricks", "redshift", "spark_iceberg"] # TODO: Add RS self-hosted runner
+        warehouse: ["postgres", "bigquery", "snowflake", "databricks", "spark_iceberg"] # TODO: Add RS self-hosted runner
     services:
       postgres:
         image: postgres:latest


### PR DESCRIPTION
## Description & motivation
Temporary pause on redshift within CI, not affecting package logic, can be merged.
